### PR TITLE
Add Connection class, to allow for non-global use.

### DIFF
--- a/thunderdome/connection.py
+++ b/thunderdome/connection.py
@@ -21,11 +21,10 @@ from collections import namedtuple
 import httplib
 import json
 import logging
-import Queue
 import random
 import re
 import socket
-import textwrap
+import time
 
 from thunderdome.exceptions import ThunderdomeException
 from thunderdome.spec import Spec
@@ -76,48 +75,204 @@ class ThunderdomeGraphMissingError(ThunderdomeException):
 
 
 Host = namedtuple('Host', ['name', 'port'])
-_hosts = []
-_host_idx = 0
-_graph_name = None
-_username = None
-_password = None
-_index_all_fields = True
-_existing_indices = None
-_statsd = None
 
 
-def create_key_index(name):
-    """
-    Creates a key index if it does not already exist
-    """
-    global _existing_indices
-    _existing_indices = _existing_indices or execute_query('g.getIndexedKeys(Vertex.class)')
-    if name not in _existing_indices:
-        execute_query(
-            "g.createKeyIndex(keyname, Vertex.class); g.stopTransaction(SUCCESS)",
-            {'keyname':name}, transaction=False)
-        _existing_indices = None
+class Connection(object):
 
+    def __init__(self,
+                 hosts,
+                 graph_name,
+                 username=None,
+                 password=None,
+                 index_all_fields=False,
+                 statsd=None,
+                ):
+        """
+        Records the hosts and connects to one of them.
+
+        :param hosts: list of hosts, strings in the <hostname>:<port> or just
+            <hostname> format
+        :type hosts: list of str
+        :param graph_name: The name of the graph as defined in the rexster.xml
+        :type graph_name: str
+        :param username: The username for the rexster server
+        :type username: str
+        :param password: The password for the rexster server
+        :type password: str
+        :param index_all_fields: Toggle automatic indexing of all vertex fields
+        :type index_all_fields: boolean
+        :param statsd: host:port or just host of statsd server to report
+            metrics to
+        :type statsd: str
+        :rtype None
+        """
+        self._hosts = []
+        self._graph_name = graph_name
+        self._username = username
+        self._password = password
+        self._index_all_fields = index_all_fields
+        self._existing_indices = None
+        self._statsd = statsd
+
+        if statsd:
+            try:
+                sd = statsd
+                import statsd
+                tmp = sd.split(':')
+                if len(tmp) == 1:
+                    tmp.append('8125')
+                self._statsd = statsd.StatsClient(tmp[0],
+                                    int(tmp[1]), prefix='thunderdome')
+            except ImportError:
+                logging.warning("Statsd configured but not installed.  "
+                                "Please install the statsd package.")
+            except:
+                raise
+
+        for host in hosts:
+            host = host.strip()
+            host = host.split(':')
+            if len(host) == 1:
+                self._hosts.append(Host(host[0], 8182))
+            elif len(host) == 2:
+                self._hosts.append(Host(*host))
+            else:
+                raise ThunderdomeConnectionError(
+                            "Can't parse {}".format(''.join(host)))
+
+        if not self._hosts:
+            raise ThunderdomeConnectionError("At least one host required")
+
+        random.shuffle(self._hosts)
         
-def create_unique_index(name, data_type):
-    """
-    Creates a key index if it does not already exist
-    """
-    global _existing_indices
-    _existing_indices = _existing_indices or execute_query('g.getIndexedKeys(Vertex.class)')
+        self.create_unique_index('vid', 'String')
+
+        #index any models that have already been defined
+        from thunderdome.models import vertex_types
+        for klass in vertex_types.values():
+            klass._create_indices()
+
+    def create_key_index(self, name):
+        """
+        Creates a key index if it does not already exist
+        """
+        if not self._existing_indices:
+            self._existing_indices= self.execute_query(
+                                        'g.getIndexedKeys(Vertex.class)')
+        if name not in self._existing_indices:
+            self.execute_query(
+                "g.createKeyIndex(keyname, Vertex.class); "
+                "g.stopTransaction(SUCCESS)",
+                {'keyname': name}, transaction=False)
+            self._existing_indices = None
+        
+    def create_unique_index(self, name, data_type):
+        """
+        Creates a key index if it does not already exist
+        """
+        if not self._existing_indices:
+            self._existing_indices = self.execute_query(
+                                        'g.getIndexedKeys(Vertex.class)')
+        
+        if name not in self._existing_indices:
+            self.execute_query(
+                "g.makeType().name(name).dataType({}.class)"
+                    ".functional().unique().indexed().makePropertyKey(); "
+                    "g.stopTransaction(SUCCESS)".format(data_type),
+                {'name': name}, transaction=False)
+            self._existing_indices = None
     
-    if name not in _existing_indices:
-        execute_query(
-            "g.makeType().name(name).dataType({}.class).functional().unique().indexed().makePropertyKey(); g.stopTransaction(SUCCESS)".format(data_type),
-            {'name':name}, transaction=False)
-        _existing_indices = None
+    def execute_query(self, query, params={}, transaction=True, context=""):
+        """
+        Execute a raw Gremlin query with the given parameters passed in.
+
+        :param query: The Gremlin query to be executed
+        :type query: str
+        :param params: Parameters to the Gremlin query
+        :type params: dict
+        :param context: String context data to include with the query for
+            stats logging
+        :rtype: dict
+        
+        """
+        if transaction:
+            query = "g.stopTransaction(FAILURE)\n" + query
+        
+        host = self._hosts[0]
+        data = json.dumps({'script':query, 'params': params})
+        headers = {'Content-Type':'application/json',
+                   'Accept':'application/json',
+                   'Accept-Charset':'utf-8',
+                  }
+        try:
+            start_time = time.time()
+            conn = httplib.HTTPConnection(host.name, host.port)
+            conn.request("POST",
+                         '/graphs/{}/tp/gremlin'.format(self._graph_name),
+                         data, headers)
+            response = conn.getresponse()
+            content = response.read()
+
+            total_time = int((time.time() - start_time) * 1000)
+
+            if context and self._statsd:
+                self._statsd.timing("{}.timer".format(context), total_time)
+                self._statsd.incr("{}.counter".format(context))
+
+
+        except socket.error as sock_err:
+            if self._statsd:
+                total_time = int((time.time() - start_time) * 1000)
+                self._statsd.incr("thunderdome.socket_error".format(context),
+                             total_time)
+            raise ThunderdomeQueryError(
+                        'Socket error during query - {}'.format(sock_err))
+        except:
+            raise
+        
+        logger.info(json.dumps(data))
+        logger.info(content)
+
+        try:
+            response_data = json.loads(content)
+        except ValueError as ve:
+            raise ThunderdomeQueryError(
+                'Loading Rexster results failed: "{}"'.format(ve))
+        
+        if response.status != 200:
+            if 'message' in response_data and len(response_data['message']) > 0:
+                graph_missing_re = r"Graph \[(.*)\] could not be found"
+                if re.search(graph_missing_re, response_data['message']):
+                    raise ThunderdomeGraphMissingError(response_data['message'])
+                else:
+                    raise ThunderdomeQueryError(
+                        response_data['message'],
+                        response_data
+                    )
+            else:
+                if self._statsd:
+                    self._statsd.incr("{}.error".format(context))
+                raise ThunderdomeQueryError(
+                    response_data['error'],
+                    response_data
+                )
+
+        return response_data['results'] 
+
+_the_connection = None
 
         
-def setup(hosts, graph_name, username=None, password=None, index_all_fields=False, statsd=None):
+def setup(hosts,
+          graph_name,
+          username=None,
+          password=None,
+          index_all_fields=False,
+          statsd=None):
     """
     Records the hosts and connects to one of them.
 
-    :param hosts: list of hosts, strings in the <hostname>:<port> or just <hostname> format
+    :param hosts: list of hosts, strings in the <hostname>:<port> or just
+        <hostname> format
     :type hosts: list of str
     :param graph_name: The name of the graph as defined in the rexster.xml
     :type graph_name: str
@@ -131,54 +286,38 @@ def setup(hosts, graph_name, username=None, password=None, index_all_fields=Fals
     :type statsd: str
     :rtype None
     """
-    global _hosts
-    global _graph_name
-    global _username
-    global _password
-    global _index_all_fields
-    global _statsd
+    global _the_connection
+    if _the_connection is not None:
+        raise ValueError('setup() already called')
+    _the_connection = Connection(hosts, graph_name, username, password,
+                                 index_all_fields, statsd)
 
-    _graph_name = graph_name
-    _username = username
-    _password = password
-    _index_all_fields = index_all_fields
+def destroy():
+    global _the_connection
+    if _the_connection is None:
+        raise ValueError('setup() not called')
+    _the_connection = None
 
 
-    if statsd:
-        try:
-            sd = statsd
-            import statsd
-            tmp = sd.split(':')
-            if len(tmp) == 1:
-                tmp.append('8125')
-            _statsd = statsd.StatsClient(tmp[0], int(tmp[1]), prefix='thunderdome')
-        except ImportError:
-            logging.warning("Statsd configured but not installed.  Please install the statsd package.")
-        except:
-            raise
+def create_key_index(name):
+    """
+    Creates a key index if it does not already exist
+    """
+    if _the_connection is None:
+        raise ValueError('setup() not called')
 
-    for host in hosts:
-        host = host.strip()
-        host = host.split(':')
-        if len(host) == 1:
-            _hosts.append(Host(host[0], 8182))
-        elif len(host) == 2:
-            _hosts.append(Host(*host))
-        else:
-            raise ThunderdomeConnectionError("Can't parse {}".format(''.join(host)))
+    return _the_connection.create_key_index(name)
 
-    if not _hosts:
-        raise ThunderdomeConnectionError("At least one host required")
+        
+def create_unique_index(name, data_type):
+    """
+    Creates a key index if it does not already exist
+    """
+    if _the_connection is None:
+        raise ValueError('setup() not called')
 
-    random.shuffle(_hosts)
-    
-    create_unique_index('vid', 'String')
-
-    #index any models that have already been defined
-    from thunderdome.models import vertex_types
-    for klass in vertex_types.values():
-        klass._create_indices()
-    
+    return _the_connection.create_unique_index(name, data_type)
+ 
     
 def execute_query(query, params={}, transaction=True, context=""):
     """
@@ -188,71 +327,15 @@ def execute_query(query, params={}, transaction=True, context=""):
     :type query: str
     :param params: Parameters to the Gremlin query
     :type params: dict
-    :param context: String context data to include with the query for stats logging
+    :param context: String context data to include with the query for stats
+        logging
     :rtype: dict
     
     """
-    if transaction:
-        query = "g.stopTransaction(FAILURE)\n" + query
+    if _the_connection is None:
+        raise ValueError('setup() not called')
 
-    # If we have no hosts available raise an exception
-    if len(_hosts) <= 0:
-        raise ThunderdomeConnectionError('Attempt to execute query before calling thunderdome.connection.setup')
-    
-    host = _hosts[0]
-    #url = 'http://{}/graphs/{}/tp/gremlin'.format(host.name, _graph_name)
-    data = json.dumps({'script':query, 'params': params})
-    headers = {'Content-Type':'application/json', 'Accept':'application/json', 'Accept-Charset':'utf-8'}
-    import time
-    try:
-        start_time = time.time()
-        conn = httplib.HTTPConnection(host.name, host.port)
-        conn.request("POST", '/graphs/{}/tp/gremlin'.format(_graph_name), data, headers)
-        response = conn.getresponse()
-        content = response.read()
-
-        total_time = int((time.time() - start_time) * 1000)
-
-        if context and _statsd:
-            _statsd.timing("{}.timer".format(context), total_time)
-            _statsd.incr("{}.counter".format(context))
-
-
-    except socket.error as sock_err:
-        if _statsd:
-            total_time = int((time.time() - start_time) * 1000)
-            _statsd.incr("thunderdome.socket_error".format(context), total_time)
-        raise ThunderdomeQueryError('Socket error during query - {}'.format(sock_err))
-    except:
-        raise
-    
-    logger.info(json.dumps(data))
-    logger.info(content)
-
-    try:
-        response_data = json.loads(content)
-    except ValueError as ve:
-        raise ThunderdomeQueryError('Loading Rexster results failed: "{}"'.format(ve))
-    
-    if response.status != 200:
-        if 'message' in response_data and len(response_data['message']) > 0:
-            graph_missing_re = r"Graph \[(.*)\] could not be found"
-            if re.search(graph_missing_re, response_data['message']):
-                raise ThunderdomeGraphMissingError(response_data['message'])
-            else:
-                raise ThunderdomeQueryError(
-                    response_data['message'],
-                    response_data
-                )
-        else:
-            if _statsd:
-                _statsd.incr("{}.error".format(context))
-            raise ThunderdomeQueryError(
-                response_data['error'],
-                response_data
-            )
-
-    return response_data['results'] 
+    return _the_connection.execute_query(query, params, transaction, context)
 
 
 def sync_spec(filename, host, graph_name, dry_run=False):

--- a/thunderdome/connection.py
+++ b/thunderdome/connection.py
@@ -299,27 +299,33 @@ def destroy():
     _the_connection = None
 
 
-def create_key_index(name):
+def create_key_index(name, conn=None):
     """
     Creates a key index if it does not already exist
     """
-    if _the_connection is None:
+    if conn is None:
+        conn = _the_connection
+
+    if conn is None:
         raise ValueError('setup() not called')
 
-    return _the_connection.create_key_index(name)
+    return conn.create_key_index(name)
 
         
-def create_unique_index(name, data_type):
+def create_unique_index(name, data_type, conn=None):
     """
     Creates a key index if it does not already exist
     """
-    if _the_connection is None:
+    if conn is None:
+        conn = _the_connection
+
+    if conn is None:
         raise ValueError('setup() not called')
 
-    return _the_connection.create_unique_index(name, data_type)
+    return conn.create_unique_index(name, data_type)
  
     
-def execute_query(query, params={}, transaction=True, context=""):
+def execute_query(query, params={}, transaction=True, context="", conn=None):
     """
     Execute a raw Gremlin query with the given parameters passed in.
 
@@ -332,10 +338,13 @@ def execute_query(query, params={}, transaction=True, context=""):
     :rtype: dict
     
     """
-    if _the_connection is None:
+    if conn is None:
+        conn = _the_connection
+
+    if conn is None:
         raise ValueError('setup() not called')
 
-    return _the_connection.execute_query(query, params, transaction, context)
+    return conn.execute_query(query, params, transaction, context)
 
 
 def sync_spec(filename, host, graph_name, dry_run=False):

--- a/thunderdome/gremlin.py
+++ b/thunderdome/gremlin.py
@@ -131,6 +131,7 @@ class BaseGremlinMethod(object):
         :type instance: object
 
         """
+        conn = kwargs.pop('conn', None)
         self._setup()
 
         args = list(args)
@@ -176,11 +177,12 @@ class BaseGremlinMethod(object):
 
             context = "{}.{}".format(context, self.method_name)
 
-            _get_connection = getattr(instance, '_get_connection', None)
-            if _get_connection is None:
-                conn = connection._the_connection
-            else:
-                conn = _get_connection()
+            if conn is None:
+                _get_connection = getattr(instance, '_get_connection', None)
+                if _get_connection is None:
+                    conn = connection._the_connection
+                else:
+                    conn = _get_connection()
             tmp = conn.execute_query(self.function_body, params,
                                      transaction=self.transaction,
                                      context=context)

--- a/thunderdome/tests/base.py
+++ b/thunderdome/tests/base.py
@@ -26,8 +26,12 @@ class BaseThunderdomeTestCase(TestCase):
     @classmethod
     def setUpClass(cls):
         super(BaseThunderdomeTestCase, cls).setUpClass()
-        if not connection._hosts:
-            connection.setup(['localhost'], 'thunderdome')
+        connection.setup(['localhost'], 'thunderdome')
+
+    @classmethod
+    def tearDownClass(cls):
+        super(BaseThunderdomeTestCase, cls).setUpClass()
+        connection.destroy()
 
     def assertHasAttr(self, obj, attr):
         self.assertTrue(hasattr(obj, attr), 

--- a/thunderdome/tests/model/test_paginated_vertex.py
+++ b/thunderdome/tests/model/test_paginated_vertex.py
@@ -17,16 +17,9 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-from unittest import skip
-from thunderdome import connection 
 from thunderdome.tests.base import BaseThunderdomeTestCase
-
-
-from thunderdome import gremlin
-from thunderdome import models
 from thunderdome.models import Edge, PaginatedVertex
 from thunderdome import properties
-import unittest
 
 
 
@@ -40,7 +33,7 @@ class TestPEdge(Edge):
 
 
 
-class PaginatedVertexTest(unittest.TestCase):
+class PaginatedVertexTest(BaseThunderdomeTestCase):
     def test_traversal(self):
         t = TestPModel.create()
         t2 = TestPModel.create()

--- a/thunderdome/tests/model/test_vertex_traversals.py
+++ b/thunderdome/tests/model/test_vertex_traversals.py
@@ -19,7 +19,6 @@
 
 from datetime import datetime
 
-from thunderdome import connection 
 from thunderdome.tests.base import BaseThunderdomeTestCase
 
 from thunderdome.models import Vertex, Edge, IN, OUT, BOTH, GREATER_THAN, LESS_THAN
@@ -55,6 +54,7 @@ class BaseTraversalTestCase(BaseThunderdomeTestCase):
         :param cls:
         :return:
         """
+        super(BaseTraversalTestCase, cls).setUpClass()
         cls.jon = Person.create(name='Jon', age=143)
         cls.eric = Person.create(name='Eric', age=25)
         cls.blake = Person.create(name='Blake', age=14)


### PR DESCRIPTION
Preserve global APIs 'setup', 'execute_query', etc., using a global instance of that class.

'Vertex' and 'Element' subclasses can be assigned an instance via '_set_connection', or have one passed in the class suite as '_connection';  in either case the global instance will be ignored (and need not even be configured).

Making the classes independent of the connection would be even more flexible, but would involve moving all the class methods, as well as the instance construction, to the connection object.
